### PR TITLE
Split windows from left to right, rightmost is bottom

### DIFF
--- a/autoload/bindsplit.vim
+++ b/autoload/bindsplit.vim
@@ -32,13 +32,15 @@ function! bindsplit#vsplit(...) abort
         let l:count=1
     endif
     echom l:count
-    let l:curwin=winnr()
+    let l:origwin=winnr()
     for i in range(1, l:count)
         vsplit
-        setlocal noscrollbind
+        execute (winnr() + 1) . "wincmd w"
         execute "normal! z+"
+    endfor
+    for i in range(l:count, 0, -1)
+        execute (l:origwin + i) . "wincmd w"
         setlocal scrollbind
     endfor
-    execute l:curwin . "wincmd w"
-    setlocal scrollbind
+    execute l:origwin . "wincmd w"
 endfunction


### PR DESCRIPTION
I've made some changes, first the `scrollbind` was only getting applied to the LHS window, so it wasn't working. Also, made it so that the panes read left-to-right not right-to-left, more like a newspaper.

Tested with VIM version 8.2.3877 and neovim v0.6.1.